### PR TITLE
Fix: vela CLI check default kubeconfig existence

### DIFF
--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -273,7 +273,11 @@ func SetDefaultKubeConfigEnv() {
 	kubeconfig := os.Getenv(RecommendedConfigPathEnvVar)
 	if kubeconfig == "" {
 		kubeconfig = GetDefaultVelaDKubeconfigPath()
-		_ = os.Setenv(RecommendedConfigPathEnvVar, kubeconfig)
+		// check default kubeconfig existence
+		_, err := os.Stat(kubeconfig)
+		if err == nil {
+			_ = os.Setenv(RecommendedConfigPathEnvVar, kubeconfig)
+		}
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: qiaozp <chivalry.pp@gmail.com>

Vela CLI installed by VelaD will set a default KUBECONFIG which is created by `velad install`. However, if this kubeconfig doesn't exist (User haven't run `velad install`) this behavior is wrong.

This PR add logic for check the existence of default velad kubeconfig.