### PR TITLE
Feat: add node external ip

### DIFF
--- a/pkg/cluster/common.go
+++ b/pkg/cluster/common.go
@@ -12,7 +12,7 @@ func GetK3sServerArgs(args apis.InstallArgs) []string {
 		serverArgs = append(serverArgs, "--datastore-endpoint="+args.DBEndpoint)
 	}
 	if args.BindIP != "" {
-		serverArgs = append(serverArgs, "--tls-san="+args.BindIP)
+		serverArgs = append(serverArgs, "--tls-san="+args.BindIP, "--node-external-ip="+args.BindIP)
 	}
 	if args.Token != "" {
 		serverArgs = append(serverArgs, "--token="+args.Token)


### PR DESCRIPTION
Add --node-external-ip to k3s server bootstrap config if the --bind-ip parameter is used in velad.

This allows user to create LoadBalancer in k3s (velad) with exposed external ip as the bond ip.