### PR TITLE
Fix: wrong cached k3d-tool image

### DIFF
--- a/hack/download_k3d_images.sh
+++ b/hack/download_k3d_images.sh
@@ -7,7 +7,7 @@ K3D_IMAGE_DIR=pkg/resources/static/k3d/images
 mkdir -p "$K3D_IMAGE_DIR"
 
 function download_k3d_images() {
-  vela_images=("ghcr.io/k3d-io/k3d-tools:5.4.1"
+  vela_images=("ghcr.io/k3d-io/k3d-tools:latest"
     "ghcr.io/k3d-io/k3d-proxy:5.4.1"
     "docker.io/rancher/k3s:v1.21.10-k3s1")
 

--- a/pkg/apis/types.go
+++ b/pkg/apis/types.go
@@ -120,7 +120,7 @@ var (
 	// K3dImageK3s is k3s image tag
 	K3dImageK3s = "rancher/k3s:v1.21.10-k3s1"
 	// K3dImageTools is k3d tools image tag
-	K3dImageTools = "ghcr.io/k3d-io/k3d-tools:5.4.1"
+	K3dImageTools = "ghcr.io/k3d-io/k3d-tools:latest"
 	// K3dImageProxy is k3d proxy image tag
 	K3dImageProxy = "ghcr.io/k3d-io/k3d-proxy:5.4.1"
 


### PR DESCRIPTION
K3d v5.4.1 use k3d-tools:latest to importing image. Update this image.