### PR TITLE
Bump k3s to v1.24.8, gateway use traefik by default

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -45,26 +45,50 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [ build-artifact ]
     steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.19
+      - name: Install ginkgo
+        run: go install github.com/onsi/ginkgo/ginkgo@v1.16.5
       - uses: actions/download-artifact@v3
         with:
           name: velad-linux-amd64
-      - run: chmod u+x velad-linux-amd64 && mv velad-linux-amd64 velad
-      - run: sudo ./velad install
-      - run: sudo vela def list
-      - run: sudo vela addon enable /root/.vela/addons/velaux
+      - run: |
+          chmod u+x velad-linux-amd64 && mv velad-linux-amd64 velad
+          sudo ./velad install
+          sudo chmod a+r $(./velad kubeconfig --host)
+          kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=vela-core --timeout=180s -n vela-system --kubeconfig=$(./velad kubeconfig --host)
+          sudo vela addon enable /root/.vela/addons/velaux
+      - name: Run e2e test
+        run: ginkgo -v ./test/e2e-test
   test-darwin:
     runs-on: macos-12
     needs: [ build-artifact ]
     steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.19
+      - name: Install ginkgo
+        run: go install github.com/onsi/ginkgo/ginkgo@v1.16.5
       - uses: actions/download-artifact@v3
         with:
           name: velad-darwin-amd64
       - name: Setup Docker
         uses: docker-practice/actions-setup-docker@1.0.11
-      - run: chmod u+x velad-darwin-amd64 && mv velad-darwin-amd64 velad
-      - run: ./velad install
-      - run: vela def list
-      - run: vela addon enable ~/.vela/addons/velaux
+      - run: |
+          chmod u+x velad-darwin-amd64 && mv velad-darwin-amd64 velad
+          ./velad install
+          export KUBECONFIG=$(./velad kubeconfig --host)
+          kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=vela-core --timeout=180s -n vela-system
+          vela addon enable ~/.vela/addons/velaux
+#      TODO(qiaozp): fix the issue of e2e test on darwin
+#      - name: Run e2e test
+#        run: ginkgo -v ./test/e2e-test
+
 #  test-linux-arm64:
 #    runs-on: ubuntu-20.04
 #    needs: [ build-artifact ]

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -35,7 +35,7 @@ jobs:
           echo ::set-output name=ARCH::${TARGETS#*/}
       - name: Build
         run: |
-          OS=${{ steps.get_matrix.outputs.OS }} ARCH=${{ steps.get_matrix.outputs.ARCH }} make ${{ steps.get_matrix.outputs.OS }}-${{ steps.get_matrix.outputs.ARCH }}
+          make ${{ steps.get_matrix.outputs.OS }}-${{ steps.get_matrix.outputs.ARCH }}
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -6,25 +6,29 @@ This guild helps you get started developing VelaD
 
 1. Golang version 1.19+
 2. Docker (for non-linux user)
-3. golangci-lint 1.38.0+, it will install automatically if you run make, you can install it [manually](https://golangci-lint.run/usage/install/#local-installation) if the installation is too slow.
+3. golangci-lint 1.38.0+, it will install automatically if you run make, you can install
+   it [manually](https://golangci-lint.run/usage/install/#local-installation) if the installation is too slow.
 
 ### Build
 
 1. Clone this project
+
 ```shell
 git clone https://github.com/kubevela/velad.git
 cd velad
 ```
+
 2. Build VelaD
 
 ```shell
 make
 ```
-This will build amd64-linux version of VelaD by default. To build other version, you need to specify `OS` and `ARCH`
-and the target. For example, you can build a darwin-amd64 version by:
+
+This will build the VelaD version corresponding to your machines architecture and OS by default. To cross build other
+version, you can the target. For example, you can build a darwin-amd64 version by:
 
 ```shell
-OS=darwin ARCH=amd64 make darwin-amd64
+make darwin-amd64
 ```
 
 ### Debug
@@ -33,7 +37,8 @@ When use IDE to debug VelaD, you need to do several things
 
 1. Download resources needed
 
-If you want build linux version, run 
+If you want build linux version, run
+
 ```shell
 VELAUX_VERSION=v1.x.y VELA_VERSION=v1.z.w make download_vela_images_addons 
 make download_k3s_bin_script 
@@ -50,7 +55,8 @@ make pack_vela_chart
 make download_k3s_images
 ```
 
-`VELAUX_VERSION=v1.x.y VELA_VERSION=v1.z.w` is optional environment variables if you want to change the default version in makefile.
+`VELAUX_VERSION=v1.x.y VELA_VERSION=v1.z.w` is optional environment variables if you want to change the default version
+in makefile.
 
 2. Build VelaD
 
@@ -66,7 +72,6 @@ cmd/velad/main.go
 > Ldflags can help to inject vela-core and VelaUX version. (Can be different)
 > If you are using IDE to debug, remember to add `-ldflags="-X github.com...` part to build option.
 
-
 ### Create a pull request
 
 Before you submit a PR, run this command to ensure it is ready:
@@ -74,4 +79,6 @@ Before you submit a PR, run this command to ensure it is ready:
 ```shell
 make reviewable
 ```
-For other PR things you can check the document [here](https://kubevela.net/docs/contributor/code-contribute#create-a-pull-request).
+
+For other PR things you can check the
+document [here](https://kubevela.net/docs/contributor/code-contribute#create-a-pull-request).

--- a/go.mod
+++ b/go.mod
@@ -9,10 +9,13 @@ require (
 	github.com/k3d-io/k3d/v5 v5.4.1
 	github.com/kyokomi/emoji/v2 v2.2.9
 	github.com/oam-dev/kubevela v1.6.4
+	github.com/onsi/ginkgo v1.16.5
+	github.com/onsi/gomega v1.20.2
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.4.0
 	github.com/stretchr/testify v1.7.1
 	helm.sh/helm/v3 v3.7.2
+	k8s.io/apimachinery v0.23.6
 	k8s.io/client-go v0.23.6
 	k8s.io/klog/v2 v2.60.1
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
@@ -198,12 +201,12 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/nacos-group/nacos-sdk-go/v2 v2.1.0 // indirect
+	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/oam-dev/cluster-gateway v1.4.0 // indirect
 	github.com/oam-dev/cluster-register v1.0.4-0.20220928064144-5f76a9d7ca8c // indirect
 	github.com/oam-dev/terraform-config-inspect v0.0.0-20210418082552-fc72d929aa28 // indirect
 	github.com/oam-dev/terraform-controller v0.7.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
-	github.com/onsi/gomega v1.20.2 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.3-0.20220114050600-8b9d41f48198 // indirect
 	github.com/opencontainers/runc v1.1.3 // indirect
@@ -287,6 +290,7 @@ require (
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
 	gopkg.in/src-d/go-billy.v4 v4.3.2 // indirect
 	gopkg.in/src-d/go-git.v4 v4.13.1 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
@@ -296,7 +300,6 @@ require (
 	istio.io/gogo-genproto v0.0.0-20211208193508-5ab4acc9eb1e // indirect
 	k8s.io/api v0.23.6 // indirect
 	k8s.io/apiextensions-apiserver v0.23.6 // indirect
-	k8s.io/apimachinery v0.23.6 // indirect
 	k8s.io/apiserver v0.23.6 // indirect
 	k8s.io/cli-runtime v0.23.6 // indirect
 	k8s.io/component-base v0.23.6 // indirect

--- a/hack/download_k3d_images.sh
+++ b/hack/download_k3d_images.sh
@@ -7,11 +7,11 @@ K3D_IMAGE_DIR=pkg/resources/static/k3d/images
 mkdir -p "$K3D_IMAGE_DIR"
 
 function download_k3d_images() {
-  vela_images=("ghcr.io/k3d-io/k3d-tools:latest"
-    "ghcr.io/k3d-io/k3d-proxy:5.4.1"
-    "docker.io/rancher/k3s:v1.21.10-k3s1")
+  k3d_images=("ghcr.io/k3d-io/k3d-tools:latest"
+    "ghcr.io/k3d-io/k3d-proxy:5.4.6"
+    "docker.io/rancher/k3s:v1.24.8-k3s1")
 
-  for IMG in ${vela_images[*]}; do
+  for IMG in ${k3d_images[*]}; do
     IMAGE_NAME=$(echo "$IMG" | cut -f1 -d: | cut -f3 -d/)
     echo saving "$IMG" to "$K3D_IMAGE_DIR"/"$IMAGE_NAME".tar
     $DOCKER_PULL "$IMG"

--- a/pkg/apis/types.go
+++ b/pkg/apis/types.go
@@ -118,7 +118,7 @@ var (
 	VelaDDockerNetwork = "k3d-velad"
 
 	// K3dImageK3s is k3s image tag
-	K3dImageK3s = "rancher/k3s:v1.21.10-k3s1"
+	K3dImageK3s = "rancher/k3s:v1.24.8-k3s1"
 	// K3dImageTools is k3d tools image tag
 	K3dImageTools = "ghcr.io/k3d-io/k3d-tools:latest"
 	// K3dImageProxy is k3d proxy image tag

--- a/pkg/cluster/k3d.go
+++ b/pkg/cluster/k3d.go
@@ -51,7 +51,7 @@ type k3dSetupOptions struct {
 
 const (
 	// K3dImageTag is image tag of k3d
-	K3dImageTag = "v1.21.10-k3s1"
+	K3dImageTag = "v1.24.8-k3s1"
 )
 
 func init() {

--- a/pkg/resources/static/vela/charts/vela-core/templates/defwithtemplate/gateway.yaml
+++ b/pkg/resources/static/vela/charts/vela-core/templates/defwithtemplate/gateway.yaml
@@ -95,7 +95,7 @@ spec:
         	http: [string]: int
 
         	// +usage=Specify the class of ingress to use
-        	class: *"nginx" | string
+        	class: *"traefik" | string
 
         	// +usage=Set ingress class in '.spec.ingressClassName' instead of 'kubernetes.io/ingress.class' annotation.
         	classInSpec: *false | bool

--- a/test/e2e-test/ingress_test.go
+++ b/test/e2e-test/ingress_test.go
@@ -1,0 +1,72 @@
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/common"
+	"github.com/oam-dev/kubevela/apis/core.oam.dev/v1beta1"
+	"github.com/oam-dev/kubevela/pkg/oam/util"
+	"github.com/oam-dev/velad/pkg/apis"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os/exec"
+	"runtime"
+	"time"
+)
+
+var _ = Describe("Ingress Test", func() {
+	Context("Test Traefik Ingress", func() {
+		It("Test Traefik Ingress", func() {
+			By("Create Application with gateway trait")
+			ctx := context.Background()
+			app := v1beta1.Application{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test-ingress",
+					Namespace: "default",
+				},
+				Spec: v1beta1.ApplicationSpec{
+					Components: []common.ApplicationComponent{
+						{
+							Name: "test",
+							Type: "webservice",
+							Properties: util.Object2RawExtension(map[string]interface{}{
+								"image": "crccheck/hello-world",
+							}),
+							Traits: []common.ApplicationTrait{
+								{
+									Type: "gateway",
+									Properties: util.Object2RawExtension(map[string]interface{}{
+										"domain": "testsvc.example.com",
+										"http": map[string]interface{}{
+											"/": 8000,
+										},
+									}),
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, &app)).Should(Succeed())
+
+			By("Check Ingress works")
+			// We can't set Host header in http go client, so we have to use cURL here.
+			// See https://github.com/golang/go/issues/7682
+			port := "80"
+			if runtime.GOOS != apis.GoosLinux {
+				port = "8090"
+			}
+			Eventually(func(g Gomega) {
+				curl := exec.Command("curl", "-H", "Host: testsvc.example.com", fmt.Sprintf("http://127.0.0.1:%s", port))
+				g.Expect(curl.Args).Should(ContainElement("Host: testsvc.example.com"))
+				output, err := curl.Output()
+				g.Expect(err).Should(BeNil())
+				g.Expect(string(output)).Should(ContainSubstring("Hello World"))
+			}, 30*time.Second).Should(Succeed())
+
+			By("Delete Application")
+			Expect(k8sClient.Delete(ctx, &app)).Should(Succeed())
+		})
+	})
+})

--- a/test/e2e-test/suite_test.go
+++ b/test/e2e-test/suite_test.go
@@ -1,0 +1,38 @@
+package e2e_test
+
+import (
+	"github.com/oam-dev/kubevela/pkg/utils/common"
+	"github.com/oam-dev/velad/pkg/utils"
+	"k8s.io/client-go/tools/clientcmd"
+	"os"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	k8sClient client.Client
+)
+
+func TestE2eTest(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "E2eTest Suite")
+}
+
+var _ = BeforeSuite(func() {
+	By("bootstrapping test environment")
+	configPath := utils.GetDefaultVelaDKubeconfigPath()
+	_ = os.Setenv(clientcmd.RecommendedConfigPathEnvVar, configPath)
+	cfg, err := config.GetConfig()
+	Expect(err).Should(BeNil())
+
+	scheme := common.Scheme
+
+	k8sClient, err = client.New(cfg, client.Options{
+		Scheme: scheme,
+	})
+	Expect(err).Should(BeNil())
+})


### PR DESCRIPTION
Make several enhancement in this PR:
1. Bump K3s and K3d, because KubeVela has support Kubernetes 1.24. And higher version of K3s add default IngressClass for Traefik.
2. simplify the target in makefile, user can simply run `make` to build VelaD
3. Modify `gateway` trait in vela-core charts so user can use gateway without specifying `ingressClass` with `traefik` in properties. Add test for this.
4. Add prompt for using gateway trait in Linux.

Signed-off-by: Qiaozp <qiaozhongpei.qzp@alibaba-inc.com>