### PR TITLE
Fix: auto detect k3s images tag

### DIFF
--- a/hack/download_k3d_images.sh
+++ b/hack/download_k3d_images.sh
@@ -7,9 +7,12 @@ K3D_IMAGE_DIR=pkg/resources/static/k3d/images
 mkdir -p "$K3D_IMAGE_DIR"
 
 function download_k3d_images() {
-  k3d_images=("ghcr.io/k3d-io/k3d-tools:latest"
-    "ghcr.io/k3d-io/k3d-proxy:5.4.6"
-    "docker.io/rancher/k3s:v1.24.8-k3s1")
+
+  k3d_images=(
+  "$(cat pkg/apis/types.go| grep "K3dImageK3s" |tail -n1 | cut -f2 -d'"')"
+  "$(cat pkg/apis/types.go| grep "K3dImageTools" |tail -n1 | cut -f2 -d'"')"
+  "$(cat pkg/apis/types.go| grep "K3dImageProxy" |tail -n1 | cut -f2 -d'"')"
+  )
 
   for IMG in ${k3d_images[*]}; do
     IMAGE_NAME=$(echo "$IMG" | cut -f1 -d: | cut -f3 -d/)

--- a/pkg/apis/types.go
+++ b/pkg/apis/types.go
@@ -122,7 +122,7 @@ var (
 	// K3dImageTools is k3d tools image tag
 	K3dImageTools = "ghcr.io/k3d-io/k3d-tools:latest"
 	// K3dImageProxy is k3d proxy image tag
-	K3dImageProxy = "ghcr.io/k3d-io/k3d-proxy:5.4.1"
+	K3dImageProxy = "ghcr.io/k3d-io/k3d-proxy:5.4.6"
 
 	// KubeVelaHelmRelease is helm release name for vela
 	KubeVelaHelmRelease = "kubevela"

--- a/pkg/resources/static/vela/charts/vela-core/values.yaml
+++ b/pkg/resources/static/vela/charts/vela-core/values.yaml
@@ -148,7 +148,7 @@ multicluster:
     port: 9443
     image:
       repository: oamdev/cluster-gateway
-      tag: v1.7.0-alpha.3
+      tag: v1.7.0
       pullPolicy: IfNotPresent
     resources:
       limits:

--- a/pkg/vela/kubevela.go
+++ b/pkg/vela/kubevela.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"runtime"
 	"strings"
 
 	"github.com/oam-dev/kubevela/pkg/utils/system"
@@ -67,10 +66,10 @@ func PrepareVelaChart(ctx *apis.Context) error {
 
 // LoadVelaImages load vela-core and velaUX images
 func LoadVelaImages(ctx *apis.Context) error {
-	if runtime.GOOS == apis.GoosDarwin && runtime.GOARCH == "arm64" {
-		info("Skip importing vela-core and VelaUX image on darwin-arm64")
-		return nil
-	}
+	//if runtime.GOOS == apis.GoosDarwin && runtime.GOARCH == "arm64" {
+	//	info("Skip importing vela-core and VelaUX image on darwin-arm64")
+	//	return nil
+	//}
 	var (
 		err      error
 		imageTar string


### PR DESCRIPTION
Signed-off-by: Qiaozp <qiaozhongpei.qzp@alibaba-inc.com>

1. auto detect k3s images tag
2. upgrade cluster gateway
3. release the constraint air-gapped in arm64/darwin
