### PR TITLE
Switch back k3d repo from fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/docker/docker v20.10.17+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/fatih/color v1.13.0
-	github.com/k3d-io/k3d/v5 v5.4.6
+	github.com/k3d-io/k3d/v5 v5.4.8-0.20230204095617-5324cf69fe84
 	github.com/kyokomi/emoji/v2 v2.2.9
 	github.com/oam-dev/kubevela v1.7.0
 	github.com/onsi/ginkgo v1.16.5


### PR DESCRIPTION
The change in fork has been merged to upstream: https://github.com/k3d-io/k3d/pull/1191

Signed-off-by: qiaozp <qiaozhongpei.qzp@alibaba-inc.com>