### PR TITLE
Fix: install fail for invalid Host header

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         uses: actions/setup-go@v3
         with:
-          go-version: "1.20"
+          go-version: "1.20.5"
       - name: Get matrix
         id: get_matrix
         run: |
@@ -49,7 +49,7 @@ jobs:
       - name: Install dependencies
         uses: actions/setup-go@v3
         with:
-          go-version: "1.20"
+          go-version: "1.20.5"
       - name: Install ginkgo
         run: go install github.com/onsi/ginkgo/ginkgo@v1.16.5
       - uses: actions/download-artifact@v3
@@ -71,7 +71,7 @@ jobs:
       - name: Install dependencies
         uses: actions/setup-go@v3
         with:
-          go-version: "1.20"
+          go-version: "1.20.5"
       - name: Install ginkgo
         run: go install github.com/onsi/ginkgo/ginkgo@v1.16.5
       - uses: actions/download-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.20"
+          go-version: "1.20.5"
       - name: Get release
         id: get_release
         uses: bruceadams/get-release@v1.2.2

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 include makefiles/dependency.mk
 
-K3S_VERSION ?= v1.24.8+k3s1
+K3S_VERSION ?= v1.27.2+k3s1
 STATIC_DIR := pkg/resources/static
 VELA_VERSION ?= v1.9.4
 VELAUX_VERSION ?= v1.9.2

--- a/pkg/cluster/k3d.go
+++ b/pkg/cluster/k3d.go
@@ -50,7 +50,7 @@ type k3dSetupOptions struct {
 
 const (
 	// K3dImageTag is image tag of k3d
-	K3dImageTag = "v1.24.8-k3s1"
+	K3dImageTag = "v1.27.2-k3s1"
 )
 
 func init() {

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -138,7 +138,7 @@ func Cleanup() error {
 // InfoBytes is a helper function to print a byte array
 func InfoBytes(b []byte) {
 	if len(b) != 0 {
-		Info(string(b))
+		Infof(string(b))
 	}
 }
 


### PR DESCRIPTION
This error is caused by compatibility of go 1.20.6 and moby. See https://github.com/k3d-io/k3d/issues/1321