### PR TITLE
Chore: replace deprecated command with environment file

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -22,7 +22,7 @@ jobs:
         id: auto-version
         run: |
           version="$(~/auto version)"
-          echo "::set-output name=version::$version"
+          echo "version=$version" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: auto release

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -29,10 +29,11 @@ jobs:
           go-version: "1.20.5"
       - name: Get matrix
         id: get_matrix
+        shell: bash
         run: |
           TARGETS=${{matrix.TARGETS}}
-          echo ::set-output name=OS::${TARGETS%/*}
-          echo ::set-output name=ARCH::${TARGETS#*/}
+          echo "OS=${TARGETS%/*}" >> $GITHUB_OUTPUT
+          echo "ARCH=${TARGETS#*/}" >> $GITHUB_OUTPUT
       - name: Build
         run: |
           make ${{ steps.get_matrix.outputs.OS }}-${{ steps.get_matrix.outputs.ARCH }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,10 +48,11 @@ jobs:
           echo "VELA_SHA_SHORT=$VELA_SHA_SHORT" >> $GITHUB_ENV
       - name: Get matrix
         id: get_matrix
+        shell: bash
         run: |
           TARGETS=${{matrix.TARGETS}}
-          echo ::set-output name=OS::${TARGETS%/*}
-          echo ::set-output name=ARCH::${TARGETS#*/}
+          echo "OS=${TARGETS%/*}" >> $GITHUB_OUTPUT
+          echo "ARCH=${TARGETS#*/}" >> $GITHUB_OUTPUT
       - name: Get ldflags
         id: get_ldflags
         run: |


### PR DESCRIPTION
## Description

Closes #2 

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
echo "::set-output name=version::$version"
```

```yaml
- name: Get matrix
  id: get_matrix
  run: |
    TARGETS=${{matrix.TARGETS}}
    echo ::set-output name=OS::${TARGETS%/*}
    echo ::set-output name=ARCH::${TARGETS#*/}
```

**TO-BE**

```yaml
echo "version=$version" >> $GITHUB_OUTPUT
```

```yaml
- name: Get matrix
  id: get_matri
  shell: bash
  run: |
    TARGETS=${{matrix.TARGETS}}
    echo "OS=${TARGETS%/*}" >> $GITHUB_OUTPUT
    echo "ARCH=${TARGETS#*/}" >> $GITHUB_OUTPUT
```