### PR TITLE
Chore: Add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # This file is a github code protect rule follow the codeowners https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#example-of-a-codeowners-file
 
-*                                  @chivalryq @wangyikewxgm
+*                                  @chivalryq @wangyikewxgm @roguepikachu


### PR DESCRIPTION
## Summary
- Add @roguepikachu to CODEOWNERS
- Related: https://github.com/kubevela/community/issues/271
- Related: https://github.com/kubevela/community/pull/272

## Test plan
- [ ] Confirm @roguepikachu is listed on owned paths
- [ ] Maintainer/reviewer approval


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `@roguepikachu` as a global code owner in `.github/CODEOWNERS` so they are auto-requested for all changes. Existing owners `@chivalryq` and `@wangyikewxgm` remain unchanged.

<sup>Written for commit 76c484f5e8a4d715165ae0166ab9490d48677747. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kubevela/velad/pull/164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

