### PR TITLE
Chore: Add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # This file is a github code protect rule follow the codeowners https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#example-of-a-codeowners-file
 
-*                                  @chivalryq @wangyikewxgm @roguepikachu
+*                                  @chivalryq @wangyikewxgm @roguepikachu @briankane @jerrinfrancis


### PR DESCRIPTION
## Summary
- Add @briankane and @jerrinfrancis to CODEOWNERS
- Related: https://github.com/kubevela/community/issues/274
- Related: https://github.com/kubevela/community/pull/275

## Test plan
- [ ] Confirm @briankane and @jerrinfrancis are listed on owned paths
- [ ] Maintainer/reviewer approval

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@briankane` and `@jerrinfrancis` as global CODEOWNERS so GitHub requests their reviews on all changes. Previously only `@chivalryq`, `@wangyikewxgm`, and `@roguepikachu` owned all files.

<sup>Written for commit f1197414e7ccb48ceac8031b8ce32d34b00ef798. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kubevela/velad/pull/165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

