### PR TITLE
Fix: repair macOS CI -- replace retired macos-12 runner and unmaintained Docker action

### DIFF
--- a/.github/workflows/code-lint.yaml
+++ b/.github/workflows/code-lint.yaml
@@ -38,7 +38,7 @@ jobs:
       # Linux runners ship Docker; this action is macOS-only by design.
       - name: Setup Docker
         if: runner.os == 'macOS'
-        uses: douglascamata/setup-docker-macos-action@v1
+        uses: douglascamata/setup-docker-macos-action@d5ccc6aae0ce23e7700154f5e63cc53e6433ac48 # v1.1.0
 
       - name: Download resources
         run: |
@@ -75,7 +75,7 @@ jobs:
       # Linux runners ship Docker; this action is macOS-only by design.
       - name: Setup Docker
         if: runner.os == 'macOS'
-        uses: douglascamata/setup-docker-macos-action@v1
+        uses: douglascamata/setup-docker-macos-action@d5ccc6aae0ce23e7700154f5e63cc53e6433ac48 # v1.1.0
 
       - name: Download resources
         run: |
@@ -117,7 +117,7 @@ jobs:
       # Linux runners ship Docker; this action is macOS-only by design.
       - name: Setup Docker
         if: runner.os == 'macOS'
-        uses: douglascamata/setup-docker-macos-action@v1
+        uses: douglascamata/setup-docker-macos-action@d5ccc6aae0ce23e7700154f5e63cc53e6433ac48 # v1.1.0
 
       - name: Download resources
         run: |

--- a/.github/workflows/code-lint.yaml
+++ b/.github/workflows/code-lint.yaml
@@ -22,7 +22,7 @@ jobs:
   staticcheck:
     strategy:
       matrix:
-        machines: ["ubuntu-22.04", "macos-12"]
+        machines: ["ubuntu-22.04", "macos-15-intel"]
     runs-on: ${{ matrix.machines }}
     steps:
       - name: Setup Go
@@ -59,7 +59,7 @@ jobs:
   lint:
     strategy:
       matrix:
-        machines: ["ubuntu-22.04", "macos-12"]
+        machines: ["ubuntu-22.04", "macos-15-intel"]
     runs-on: ${{ matrix.machines }}
     steps:
       - name: Setup Go
@@ -97,7 +97,7 @@ jobs:
   go-check:
     strategy:
       matrix:
-        machines: ["ubuntu-22.04", "macos-12"]
+        machines: ["ubuntu-22.04", "macos-15-intel"]
     runs-on: ${{ matrix.machines }}
     steps:
       - name: Setup Go

--- a/.github/workflows/code-lint.yaml
+++ b/.github/workflows/code-lint.yaml
@@ -35,10 +35,10 @@ jobs:
         with:
           submodules: true
 
+      # Linux runners ship Docker; this action is macOS-only by design.
       - name: Setup Docker
-        uses: docker-practice/actions-setup-docker@master
-        with:
-          docker_version: "24.0.2"
+        if: runner.os == 'macOS'
+        uses: douglascamata/setup-docker-macos-action@v1
 
       - name: Download resources
         run: |
@@ -72,10 +72,10 @@ jobs:
         with:
           submodules: true
 
+      # Linux runners ship Docker; this action is macOS-only by design.
       - name: Setup Docker
-        uses: docker-practice/actions-setup-docker@master
-        with:
-          docker_version: "24.0.2"
+        if: runner.os == 'macOS'
+        uses: douglascamata/setup-docker-macos-action@v1
 
       - name: Download resources
         run: |
@@ -114,10 +114,10 @@ jobs:
         run: |
           go mod tidy
 
+      # Linux runners ship Docker; this action is macOS-only by design.
       - name: Setup Docker
-        uses: docker-practice/actions-setup-docker@master
-        with:
-          docker_version: "24.0.2"
+        if: runner.os == 'macOS'
+        uses: douglascamata/setup-docker-macos-action@v1
 
       - name: Download resources
         run: |

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -79,7 +79,7 @@ jobs:
         with:
           name: velad-darwin-amd64
       - name: Setup Docker
-        uses: douglascamata/setup-docker-macos-action@v1
+        uses: douglascamata/setup-docker-macos-action@d5ccc6aae0ce23e7700154f5e63cc53e6433ac48 # v1.1.0
       - run: |
           chmod u+x velad-darwin-amd64 && mv velad-darwin-amd64 velad
           ./velad install --set image.pullPolicy=Never --set admissionWebhooks.patch.image.pullPolicy=Never --set multicluster.clusterGateway.image.pullPolicy=Never

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -80,6 +80,13 @@ jobs:
           name: velad-darwin-amd64
       - name: Setup Docker
         uses: douglascamata/setup-docker-macos-action@d5ccc6aae0ce23e7700154f5e63cc53e6433ac48 # v1.1.0
+      # Colima exposes its socket only as a docker CLI context. VelaD builds its
+      # Docker client with client.FromEnv (pkg/cluster/k3d.go), which reads
+      # DOCKER_HOST but knows nothing about CLI contexts, so without this it
+      # falls back to a /var/run/docker.sock that does not exist on the host and
+      # fails while inspecting the k3d network.
+      - name: Export the Colima Docker socket for Docker SDK clients
+        run: echo "DOCKER_HOST=$(docker context inspect colima -f '{{ .Endpoints.docker.Host }}')" >> "$GITHUB_ENV"
       - run: |
           chmod u+x velad-darwin-amd64 && mv velad-darwin-amd64 velad
           ./velad install --set image.pullPolicy=Never --set admissionWebhooks.patch.image.pullPolicy=Never --set multicluster.clusterGateway.image.pullPolicy=Never

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Run e2e test
         run: ginkgo -v ./test/e2e-test
   test-darwin:
-    runs-on: macos-12
+    runs-on: macos-15-intel
     needs: [build-artifact]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -79,9 +79,7 @@ jobs:
         with:
           name: velad-darwin-amd64
       - name: Setup Docker
-        uses: docker-practice/actions-setup-docker@master
-        with:
-          docker_version: "24.0.2"
+        uses: douglascamata/setup-docker-macos-action@v1
       - run: |
           chmod u+x velad-darwin-amd64 && mv velad-darwin-amd64 velad
           ./velad install --set image.pullPolicy=Never --set admissionWebhooks.patch.image.pullPolicy=Never --set multicluster.clusterGateway.image.pullPolicy=Never

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -87,6 +87,22 @@ jobs:
       # fails while inspecting the k3d network.
       - name: Export the Colima Docker socket for Docker SDK clients
         run: echo "DOCKER_HOST=$(docker context inspect colima -f '{{ .Endpoints.docker.Host }}')" >> "$GITHUB_ENV"
+      # The macOS runner image ships no kubectl. Pin it to the cluster's minor
+      # version -- VelaD creates a Kubernetes v1.27 cluster (K3S_VERSION in the
+      # Makefile) and kubectl only supports +/-1 minor of skew, so "latest" would
+      # be badly out of range. stable.txt is deliberately avoided: that endpoint
+      # can serve CDN garbage. The published SHA256 is verified before install.
+      - name: Install kubectl
+        env:
+          KUBECTL_VERSION: v1.27.2
+        run: |
+          base="https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/darwin/amd64"
+          curl -fsSLO --retry 3 "${base}/kubectl"
+          curl -fsSLO --retry 3 "${base}/kubectl.sha256"
+          echo "$(cat kubectl.sha256)  kubectl" | shasum -a 256 --check -
+          sudo install -o root -g wheel -m 0755 kubectl /usr/local/bin/kubectl
+          rm -f kubectl kubectl.sha256
+          kubectl version --client
       - run: |
           chmod u+x velad-darwin-amd64 && mv velad-darwin-amd64 velad
           ./velad install --set image.pullPolicy=Never --set admissionWebhooks.patch.image.pullPolicy=Never --set multicluster.clusterGateway.image.pullPolicy=Never


### PR DESCRIPTION
## Summary

macOS CI is broken in four independent ways. Both `code-lint.yaml` and `e2e-test.yaml` are affected.

**1. `macos-12` runners are retired.** Jobs requesting that label are never scheduled — they sit at `status=queued` with no runner assigned until they time out, so `test-darwin`, `lint`, `staticcheck` and `go-check` never report. Replaced with `macos-15-intel`.

`macos-latest` is deliberately *not* used here: it now resolves to an arm64 image, and GitHub's arm64 macOS runners cannot run Docker at all (Apple's Virtualization Framework does not permit nested virtualization on them). `macos-15-intel` is a standard runner, free and unlimited on public repositories, and keeps the x86_64 architecture these jobs assume — `ARCH` in the `Makefile` comes from `uname -m`, so an arm64 runner also pulled `linux/arm64` images while `test-darwin` tests the `velad-darwin-amd64` artifact.

**2. `docker-practice/actions-setup-docker` no longer works.** It fetches a pinned 2021 Homebrew cask file and runs `brew install --cask docker.rb`; current Homebrew refuses to install a cask from a path:

```
##[error]Homebrew requires casks to be in a tap, rejecting:
  docker.rb (/Users/runner/work/velad/velad/docker.rb)
```

On arm64 that step reported `success` and left no `docker` binary, surfacing later as the confusing `docker: command not found` in `hack/download_vela_images.sh`. Replaced with `douglascamata/setup-docker-macos-action`, which is maintained and lists `macos-15-intel` as supported.

The step is now gated on `runner.os == 'macOS'`, since the `code-lint.yaml` matrix also runs on `ubuntu-22.04`, where Docker is preinstalled and the new action is macOS-only by design.

**3. VelaD's Docker client cannot see the Colima socket.** Colima publishes its socket only as a docker CLI context, but VelaD builds its client with `client.FromEnv` (`pkg/cluster/k3d.go`), which reads `DOCKER_HOST` and knows nothing about CLI contexts, so it fell back to a `/var/run/docker.sock` that does not exist on the host and failed at `NetworkInspect` while generating the internal kubeconfig — `DOCKER_HOST` is now exported from the context so every later step inherits it.

**4. The macOS runner image ships no `kubectl`.** `test-darwin` exited 127 on `kubectl wait` after VelaD had already installed the control plane, so `kubectl` is now downloaded from the official release host with its published SHA256 verified before install, pinned to `v1.27.2` to stay within one minor of the v1.27 cluster VelaD creates (`K3S_VERSION` in the `Makefile`).

## Test plan
- [ ] `lint`, `staticcheck`, `go-check` schedule and pass on both `ubuntu-22.04` and `macos-15-intel`
- [ ] `test-darwin` gets a runner and `velad install` finds `docker`
- [ ] No job is left permanently queued

## Notes for reviewers
- `fail-fast` is not set in `code-lint.yaml`, so it defaults to `true` — when the macOS leg died it cancelled the Linux legs, which then showed up as failures rather than cancellations. Worth considering `fail-fast: false` separately.
- A longer-term alternative would drop the Docker dependency entirely: `hack/download_vela_images.sh` and `hack/download_k3d_images.sh` only use `docker pull --platform=…` and `docker save -o …`, both of which `crane` does as a static binary with no daemon. That would make these jobs work on arm64 runners too. Left out of this PR to keep it minimal.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs macOS CI by moving to `macos-15-intel`, replacing the broken Docker setup, exporting the Colima socket for the Docker SDK, and installing `kubectl` on macOS. Previously jobs queued or failed with missing Docker/invalid socket or `kubectl`; now `test-darwin`, `lint`, `staticcheck`, and `go-check` schedule and run.

- Runners: switch `macos-12` to `macos-15-intel` in `code-lint.yaml` and `e2e-test.yaml`; keep Intel because `macos-latest` is arm64, cannot run Docker, and tests assume amd64.
- Docker setup: replace `docker-practice/actions-setup-docker` with `douglascamata/setup-docker-macos-action@d5ccc6aa` and run it only on macOS; Linux runners already have Docker.
- Docker host: export `DOCKER_HOST` from `docker context inspect colima` so VelaD’s Docker SDK connects to Colima instead of `/var/run/docker.sock`.
- `kubectl`: install v1.27.2 on macOS with SHA256 verification to match the v1.27 cluster VelaD creates.

<sup>Written for commit 6715c57777d0b7f3c0cff7fd357ee2fb2a0055fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kubevela/velad/pull/166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


